### PR TITLE
update linter test to xk6 lint changes

### DIFF
--- a/compliance.json
+++ b/compliance.json
@@ -61,7 +61,5 @@
       "passed": true
     }
   ],
-  "grade": "A",
-  "level": 100,
   "timestamp": 1744210267
 }

--- a/compliance.txt
+++ b/compliance.txt
@@ -1,9 +1,5 @@
 k6 extension compliance
-──────────┬─────────────
- grade  A │ level  100% 
 
-Details
-───────
 ✔ security            
   no issues found
 ✔ vulnerability       

--- a/test/lint.bats
+++ b/test/lint.bats
@@ -13,7 +13,7 @@ normalize() {
 }
 
 diffable() {
-  jq '{"checks":(.checks|sort_by(.id)|map({(.id):.passed})|add),"grade":.grade, "level":.level}'
+  jq '{"checks":(.checks|sort_by(.id)|map({(.id):.passed})|add)}'
 }
 
 golden_test() {


### PR DESCRIPTION
The JSON output of `xk6 lint` changes, so the linter integration test needs to be updated.

See https://github.com/grafana/xk6/issues/287