### PR TITLE
Remove redundant toolchain entry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/grafana/xk6-it
 
 go 1.23.0
 
-toolchain go1.23.8
-
 require (
 	github.com/grafana/sobek v0.0.0-20251103154147-6b40183f38e5
 	go.k6.io/k6 v1.3.0


### PR DESCRIPTION
Renovate wants to update the `toolchain` entry in the `go.mod` file. This entry is redundant, so it should be removed rather than constantly updated.