### PR TITLE
Tests for `help` and `version` commands

### DIFF
--- a/test/help.bats
+++ b/test/help.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+setup() {
+  load helpers
+  _common_setup
+  cd $BATS_TEST_TMPDIR
+
+  COMMANDS=("version" "new" "build" "run" "lint" "sync" "help")
+}
+
+@test '⚙ $(basename $BATS_TEST_FILENAME) K6_VERSION=$K6_VERSION; XK6_K6_REPO=$XK6_K6_REPO' {}
+
+# bats test_tags=xk6:help,xk6:smoke,xk6:liveness
+@test 'no args' {
+  run $XK6
+  [ $status -eq 0 ]
+  echo "$output" | grep -q 'Use "xk6 \[command\] --help" for more information about a command.'
+  for cmd in "${COMMANDS[@]}"; do
+    echo "$output" | grep -q " $cmd "
+  done
+}
+
+# bats test_tags=xk6:help,xk6:smoke,xk6:liveness
+@test 'command --help' {
+  for cmd in "${COMMANDS[@]}"; do
+    run $XK6 $cmd --help
+    [ $status -eq 0 ]
+    echo "$output" | grep -q "xk6 $cmd"
+  done
+}

--- a/test/version.bats
+++ b/test/version.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+setup() {
+  load helpers
+  _common_setup
+  cd $BATS_TEST_TMPDIR
+}
+
+@test '⚙ $(basename $BATS_TEST_FILENAME) K6_VERSION=$K6_VERSION; XK6_K6_REPO=$XK6_K6_REPO' {}
+
+# bats test_tags=xk6:version,xk6:smoke,xk6:liveness
+@test 'no args' {
+  run $XK6 version
+  [ $status -eq 0 ]
+  echo "$output" | egrep -q '^xk6 version [^[:space:]]+$'
+}
+
+# bats test_tags=xk6:version,xk6:smoke,xk6:liveness
+@test '--version' {
+  run $XK6 --version
+  [ $status -eq 0 ]
+  echo "$output" | egrep -q '^xk6 version [^[:space:]]+$'
+}
+
+# bats test_tags=xk6:version,xk6:smoke,xk6:liveness
+@test 'specific version: $XK6_VERSION' {
+  if [[ ! -v "XK6_VERSION" ]]; then
+    skip "XK6_VERSION is not set"
+  fi
+
+  run $XK6 version
+  [ $status -eq 0 ]
+  echo "$output" | grep -q "^xk6 version ${XK6_VERSION}\$"
+}


### PR DESCRIPTION
Added integration tests for `version` and `help` commands.

These tests are suitable for liveness checks, so they are tagged with `xk6:liveness`.