### PR TITLE
build: pin go toolchain to latest patch version for security

### DIFF
--- a/ext/ascii85/go.mod
+++ b/ext/ascii85/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/xk6-it/ext/ascii85
 
 go 1.25.0
 
+toolchain go1.25.10
+
 require (
 	github.com/grafana/sobek v0.0.0-20260429085637-a66d4790012b
 	go.k6.io/k6 v1.7.1

--- a/ext/base32/go.mod
+++ b/ext/base32/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/xk6-it/ext/base32
 
 go 1.25.0
 
+toolchain go1.25.10
+
 require (
 	github.com/grafana/sobek v0.0.0-20260429085637-a66d4790012b
 	go.k6.io/k6 v1.7.1

--- a/ext/base64-as-base32/go.mod
+++ b/ext/base64-as-base32/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/xk6-it/ext/base32
 
 go 1.25.0
 
+toolchain go1.25.10
+
 require (
 	github.com/grafana/sobek v0.0.0-20260429085637-a66d4790012b
 	go.k6.io/k6 v1.7.1

--- a/ext/base64/go.mod
+++ b/ext/base64/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/xk6-it/ext/base64
 
 go 1.25.0
 
+toolchain go1.25.10
+
 require (
 	github.com/grafana/sobek v0.0.0-20260429085637-a66d4790012b
 	go.k6.io/k6 v1.7.1

--- a/ext/crc32/go.mod
+++ b/ext/crc32/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/xk6-it/ext/crc32
 
 go 1.25.0
 
+toolchain go1.25.10
+
 require go.k6.io/k6 v1.7.1
 
 require (

--- a/ext/sha1/go.mod
+++ b/ext/sha1/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/xk6-it/ext/sha1
 
 go 1.25.0
 
+toolchain go1.25.10
+
 require go.k6.io/k6 v1.7.1
 
 require (

--- a/ext/sha256/go.mod
+++ b/ext/sha256/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/xk6-it/ext/sha256
 
 go 1.25.0
 
+toolchain go1.25.10
+
 require go.k6.io/k6 v1.7.1
 
 require (

--- a/ext/sha512/go.mod
+++ b/ext/sha512/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/xk6-it/ext/sha512
 
 go 1.25.0
 
+toolchain go1.25.10
+
 require go.k6.io/k6 v1.7.1
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/xk6-it
 
 go 1.25.0
 
+toolchain go1.25.10
+
 require (
 	github.com/grafana/sobek v0.0.0-20260429085637-a66d4790012b
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
Pin the Go toolchain in go.mod to the latest patch version (`v1.25.10`) of the minor it currently targets, picking up the latest security and bugfix releases.